### PR TITLE
fix: import CallArgument directly from @aptos-labs/script-composer-pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@aptos-labs/js-pro": "^0.1.1",
+    "@aptos-labs/script-composer-pack": "^0.2.0",
     "@aptos-labs/script-composer-sdk": "^0.3.0-3",
     "@aptos-labs/ts-sdk": "^4.0.0",
     "@noble/curves": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@aptos-labs/js-pro':
     specifier: ^0.1.1
     version: 0.1.4(@aptos-labs/ts-sdk@4.0.0)(typescript@5.8.3)
+  '@aptos-labs/script-composer-pack':
+    specifier: ^0.2.0
+    version: 0.2.0(@aptos-labs/aptos-dynamic-transaction-composer@0.1.4)(@aptos-labs/ts-sdk@4.0.0)
   '@aptos-labs/script-composer-sdk':
     specifier: ^0.3.0-3
     version: 0.3.0-3(@aptos-labs/aptos-dynamic-transaction-composer@0.1.4)(@aptos-labs/ts-sdk@4.0.0)

--- a/src/composer/moduleProxy.ts
+++ b/src/composer/moduleProxy.ts
@@ -1,5 +1,6 @@
 import { EntryFunctionArgumentTypes, SimpleEntryFunctionArgumentTypes, TypeArgument } from "@aptos-labs/ts-sdk";
-import type { AptosScriptComposer, CallArgument } from "@aptos-labs/script-composer-sdk";
+import type { AptosScriptComposer } from "@aptos-labs/script-composer-sdk";
+import type { CallArgument } from "@aptos-labs/script-composer-pack";
 import { ABIRoot } from "./abi";
 
 /**


### PR DESCRIPTION
- Add @aptos-labs/script-composer-pack as direct dependency
- Change CallArgument import from @aptos-labs/script-composer-sdk to @aptos-labs/script-composer-pack
- Fixes TS2459/TS2307 error during DTS generation in prepare script when installed as git dependency
- Resolves issue where CallArgument was not properly exported through re-export chain